### PR TITLE
Fix setState calls, allow Promise factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const WrappedComponent = withPromises({
 You can also pass a function to withPromise, so that you are able to fetch multiple times as the component is updated. The above example would be modified to look like this:
 
 ```js
-const WrappedComponent = withPromises((props, oldProps, oldPromises){
+const WrappedComponent = withPromises((props, oldProps, oldPromises) => {
   user: props.id !== oldProps.id ?
     fetch(`/users/${props.id}`).then(res => res.json()) :
     oldPromises.user,

--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ const WrappedComponent = withPromises({
   anotherPromiseData: Promise.resolve('random data'),
 })(MyComponent);
 ```
+
+You can also pass a function to withPromise, so that you are able to fetch multiple times as the component is updated. The above example would be modified to look like this:
+
+```js
+const WrappedComponent = withPromises((props, oldProps, oldPromises){
+  user: props.id !== oldProps.id ?
+    fetch(`/users/${props.id}`).then(res => res.json()) :
+    oldPromises.user,
+
+  anotherPromiseData: Promise.resolve('random data'),
+})(MyComponent);
+```

--- a/dist/react-hoc-promises.cjs.js
+++ b/dist/react-hoc-promises.cjs.js
@@ -249,10 +249,18 @@ var PromisesWrapper = (function(_React$Component) {
         var _this2 = this;
 
         this._mounted = true;
-        return Promise.all(Object.values(this.props.promisesMap))
+
+        var mapPromisesToProps = this.props.mapPromisesToProps;
+
+        var promisesMap =
+          typeof mapPromisesToProps === 'function'
+            ? mapPromisesToProps(this.props)
+            : mapPromisesToProps;
+
+        return Promise.all(Object.values(promisesMap))
           .then(function(datas) {
             if (_this2._mounted) {
-              var state = Object.keys(_this2.props.promisesMap).reduce(function(
+              var state = Object.keys(promisesMap).reduce(function(
                 acc,
                 key,
                 index,
@@ -305,12 +313,15 @@ var PromisesWrapper = (function(_React$Component) {
 })(React.Component);
 
 PromisesWrapper.propTypes = {
-  promisesMap: PropTypes.shape({}),
+  mapPromisesToProps: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.func,
+  ]),
   render: PropTypes.func.isRequired,
 };
 
 PromisesWrapper.defaultProps = {
-  promisesMap: {},
+  mapPromisesToProps: {},
 };
 
 function getDisplayName(WrappedComponent) {
@@ -321,7 +332,7 @@ var withPromises = function withPromises(mapPromisesToProps) {
   return function(WrappedComponent) {
     var WithPromises = function WithPromises(props) {
       return React.createElement(PromisesWrapper, {
-        promisesMap: mapPromisesToProps,
+        mapPromisesToProps: mapPromisesToProps,
         render: function render(datas) {
           return React.createElement(
             WrappedComponent,

--- a/dist/react-hoc-promises.cjs.js
+++ b/dist/react-hoc-promises.cjs.js
@@ -238,6 +238,7 @@ var PromisesWrapper = (function(_React$Component) {
     );
 
     _this.state = { loading: true };
+    _this._mounted = false;
     return _this;
   }
 
@@ -247,25 +248,28 @@ var PromisesWrapper = (function(_React$Component) {
       value: function componentDidMount() {
         var _this2 = this;
 
+        this._mounted = true;
         return Promise.all(Object.values(this.props.promisesMap))
           .then(function(datas) {
-            var state = Object.keys(_this2.props.promisesMap).reduce(function(
-              acc,
-              key,
-              index,
-            ) {
-              return _extends({}, acc, defineProperty({}, key, datas[index]));
-            },
-            {});
-            _this2.setState(
-              _extends(
-                {
-                  loading: false,
-                  error: null,
-                },
-                state,
-              ),
-            );
+            if (_this2._mounted) {
+              var state = Object.keys(_this2.props.promisesMap).reduce(function(
+                acc,
+                key,
+                index,
+              ) {
+                return _extends({}, acc, defineProperty({}, key, datas[index]));
+              },
+              {});
+              _this2.setState(
+                _extends(
+                  {
+                    loading: false,
+                    error: null,
+                  },
+                  state,
+                ),
+              );
+            }
             return datas;
           })
           .catch(function(err) {
@@ -275,6 +279,12 @@ var PromisesWrapper = (function(_React$Component) {
             });
             return err;
           });
+      },
+    },
+    {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        this._mounted = false;
       },
     },
     {

--- a/dist/react-hoc-promises.js
+++ b/dist/react-hoc-promises.js
@@ -232,6 +232,7 @@ var PromisesWrapper = (function(_React$Component) {
     );
 
     _this.state = { loading: true };
+    _this._mounted = false;
     return _this;
   }
 
@@ -241,25 +242,28 @@ var PromisesWrapper = (function(_React$Component) {
       value: function componentDidMount() {
         var _this2 = this;
 
+        this._mounted = true;
         return Promise.all(Object.values(this.props.promisesMap))
           .then(function(datas) {
-            var state = Object.keys(_this2.props.promisesMap).reduce(function(
-              acc,
-              key,
-              index,
-            ) {
-              return _extends({}, acc, defineProperty({}, key, datas[index]));
-            },
-            {});
-            _this2.setState(
-              _extends(
-                {
-                  loading: false,
-                  error: null,
-                },
-                state,
-              ),
-            );
+            if (_this2._mounted) {
+              var state = Object.keys(_this2.props.promisesMap).reduce(function(
+                acc,
+                key,
+                index,
+              ) {
+                return _extends({}, acc, defineProperty({}, key, datas[index]));
+              },
+              {});
+              _this2.setState(
+                _extends(
+                  {
+                    loading: false,
+                    error: null,
+                  },
+                  state,
+                ),
+              );
+            }
             return datas;
           })
           .catch(function(err) {
@@ -269,6 +273,12 @@ var PromisesWrapper = (function(_React$Component) {
             });
             return err;
           });
+      },
+    },
+    {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        this._mounted = false;
       },
     },
     {

--- a/dist/react-hoc-promises.js
+++ b/dist/react-hoc-promises.js
@@ -243,10 +243,18 @@ var PromisesWrapper = (function(_React$Component) {
         var _this2 = this;
 
         this._mounted = true;
-        return Promise.all(Object.values(this.props.promisesMap))
+
+        var mapPromisesToProps = this.props.mapPromisesToProps;
+
+        var promisesMap =
+          typeof mapPromisesToProps === 'function'
+            ? mapPromisesToProps(this.props)
+            : mapPromisesToProps;
+
+        return Promise.all(Object.values(promisesMap))
           .then(function(datas) {
             if (_this2._mounted) {
-              var state = Object.keys(_this2.props.promisesMap).reduce(function(
+              var state = Object.keys(promisesMap).reduce(function(
                 acc,
                 key,
                 index,
@@ -299,12 +307,15 @@ var PromisesWrapper = (function(_React$Component) {
 })(React.Component);
 
 PromisesWrapper.propTypes = {
-  promisesMap: PropTypes.shape({}),
+  mapPromisesToProps: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.func,
+  ]),
   render: PropTypes.func.isRequired,
 };
 
 PromisesWrapper.defaultProps = {
-  promisesMap: {},
+  mapPromisesToProps: {},
 };
 
 function getDisplayName(WrappedComponent) {
@@ -315,7 +326,7 @@ var withPromises = function withPromises(mapPromisesToProps) {
   return function(WrappedComponent) {
     var WithPromises = function WithPromises(props) {
       return React.createElement(PromisesWrapper, {
-        promisesMap: mapPromisesToProps,
+        mapPromisesToProps: mapPromisesToProps,
         render: function render(datas) {
           return React.createElement(
             WrappedComponent,

--- a/dist/react-hoc-promises.js
+++ b/dist/react-hoc-promises.js
@@ -238,49 +238,84 @@ var PromisesWrapper = (function(_React$Component) {
 
   createClass(PromisesWrapper, [
     {
-      key: 'componentDidMount',
-      value: function componentDidMount() {
+      key: '_setupPromises',
+      value: function _setupPromises(oldProps) {
         var _this2 = this;
-
-        this._mounted = true;
 
         var mapPromisesToProps = this.props.mapPromisesToProps;
 
+        var oldPromisesMap = this._promisesMap;
         var promisesMap =
           typeof mapPromisesToProps === 'function'
-            ? mapPromisesToProps(this.props)
+            ? mapPromisesToProps(this.props, oldProps, oldPromisesMap)
             : mapPromisesToProps;
 
-        return Promise.all(Object.values(promisesMap))
-          .then(function(datas) {
-            if (_this2._mounted) {
-              var state = Object.keys(promisesMap).reduce(function(
-                acc,
-                key,
-                index,
-              ) {
-                return _extends({}, acc, defineProperty({}, key, datas[index]));
-              },
-              {});
-              _this2.setState(
-                _extends(
-                  {
-                    loading: false,
-                    error: null,
-                  },
-                  state,
-                ),
-              );
-            }
-            return datas;
+        this._promisesMap = promisesMap;
+
+        var promises = Object.values(promisesMap);
+        var oldPromises = oldPromisesMap && Object.values(oldPromisesMap);
+        if (
+          !oldPromises ||
+          promises.length !== oldPromises.length ||
+          promises.find(function(p, i) {
+            return p !== oldPromises[i];
           })
-          .catch(function(err) {
-            _this2.setState({
-              loading: false,
-              error: err,
+        ) {
+          if (this._mounted) {
+            this.setState({
+              loading: true,
             });
-            return err;
-          });
+          }
+          this._promise = Promise.all(Object.values(promisesMap))
+            .then(function(datas) {
+              // Ignore results if this request has been superceded
+              if (_this2._mounted && promisesMap === _this2._promisesMap) {
+                var state = Object.keys(promisesMap).reduce(function(
+                  acc,
+                  key,
+                  index,
+                ) {
+                  return _extends(
+                    {},
+                    acc,
+                    defineProperty({}, key, datas[index]),
+                  );
+                },
+                {});
+                _this2.setState(
+                  _extends(
+                    {
+                      loading: false,
+                      error: null,
+                    },
+                    state,
+                  ),
+                );
+              }
+              return datas;
+            })
+            .catch(function(err) {
+              _this2.setState({
+                loading: false,
+                error: err,
+              });
+              return err;
+            });
+        }
+        return this._promise || Promise.resolve({});
+      },
+    },
+    {
+      key: 'componentDidUpdate',
+      value: function componentDidUpdate(oldProps) {
+        this._setupPromises(oldProps);
+      },
+    },
+    {
+      key: 'componentDidMount',
+      value: function componentDidMount() {
+        this._mounted = true;
+        return this._setupPromises();
       },
     },
     {

--- a/dist/react-hoc-promises.umd.js
+++ b/dist/react-hoc-promises.umd.js
@@ -1543,19 +1543,29 @@ object-assign
           var _this2 = this;
 
           this._mounted = true;
-          return Promise.all(Object.values(this.props.promisesMap))
+
+          var mapPromisesToProps = this.props.mapPromisesToProps;
+
+          var promisesMap =
+            typeof mapPromisesToProps === 'function'
+              ? mapPromisesToProps(this.props)
+              : mapPromisesToProps;
+
+          return Promise.all(Object.values(promisesMap))
             .then(function(datas) {
               if (_this2._mounted) {
-                var state = Object.keys(_this2.props.promisesMap).reduce(
-                  function(acc, key, index) {
-                    return _extends(
-                      {},
-                      acc,
-                      defineProperty({}, key, datas[index]),
-                    );
-                  },
-                  {},
-                );
+                var state = Object.keys(promisesMap).reduce(function(
+                  acc,
+                  key,
+                  index,
+                ) {
+                  return _extends(
+                    {},
+                    acc,
+                    defineProperty({}, key, datas[index]),
+                  );
+                },
+                {});
                 _this2.setState(
                   _extends(
                     {
@@ -1601,12 +1611,15 @@ object-assign
   })(React.Component);
 
   PromisesWrapper.propTypes = {
-    promisesMap: propTypes.shape({}),
+    mapPromisesToProps: propTypes.oneOfType([
+      propTypes.shape({}),
+      propTypes.func,
+    ]),
     render: propTypes.func.isRequired,
   };
 
   PromisesWrapper.defaultProps = {
-    promisesMap: {},
+    mapPromisesToProps: {},
   };
 
   function getDisplayName(WrappedComponent) {
@@ -1617,7 +1630,7 @@ object-assign
     return function(WrappedComponent) {
       var WithPromises = function WithPromises(props) {
         return React.createElement(PromisesWrapper, {
-          promisesMap: mapPromisesToProps,
+          mapPromisesToProps: mapPromisesToProps,
           render: function render(datas) {
             return React.createElement(
               WrappedComponent,

--- a/dist/react-hoc-promises.umd.js
+++ b/dist/react-hoc-promises.umd.js
@@ -1538,53 +1538,84 @@ object-assign
 
     createClass(PromisesWrapper, [
       {
-        key: 'componentDidMount',
-        value: function componentDidMount() {
+        key: '_setupPromises',
+        value: function _setupPromises(oldProps) {
           var _this2 = this;
-
-          this._mounted = true;
 
           var mapPromisesToProps = this.props.mapPromisesToProps;
 
+          var oldPromisesMap = this._promisesMap;
           var promisesMap =
             typeof mapPromisesToProps === 'function'
-              ? mapPromisesToProps(this.props)
+              ? mapPromisesToProps(this.props, oldProps, oldPromisesMap)
               : mapPromisesToProps;
 
-          return Promise.all(Object.values(promisesMap))
-            .then(function(datas) {
-              if (_this2._mounted) {
-                var state = Object.keys(promisesMap).reduce(function(
-                  acc,
-                  key,
-                  index,
-                ) {
-                  return _extends(
-                    {},
-                    acc,
-                    defineProperty({}, key, datas[index]),
-                  );
-                },
-                {});
-                _this2.setState(
-                  _extends(
-                    {
-                      loading: false,
-                      error: null,
-                    },
-                    state,
-                  ),
-                );
-              }
-              return datas;
+          this._promisesMap = promisesMap;
+
+          var promises = Object.values(promisesMap);
+          var oldPromises = oldPromisesMap && Object.values(oldPromisesMap);
+          if (
+            !oldPromises ||
+            promises.length !== oldPromises.length ||
+            promises.find(function(p, i) {
+              return p !== oldPromises[i];
             })
-            .catch(function(err) {
-              _this2.setState({
-                loading: false,
-                error: err,
+          ) {
+            if (this._mounted) {
+              this.setState({
+                loading: true,
               });
-              return err;
-            });
+            }
+            this._promise = Promise.all(Object.values(promisesMap))
+              .then(function(datas) {
+                // Ignore results if this request has been superceded
+                if (_this2._mounted && promisesMap === _this2._promisesMap) {
+                  var state = Object.keys(promisesMap).reduce(function(
+                    acc,
+                    key,
+                    index,
+                  ) {
+                    return _extends(
+                      {},
+                      acc,
+                      defineProperty({}, key, datas[index]),
+                    );
+                  },
+                  {});
+                  _this2.setState(
+                    _extends(
+                      {
+                        loading: false,
+                        error: null,
+                      },
+                      state,
+                    ),
+                  );
+                }
+                return datas;
+              })
+              .catch(function(err) {
+                _this2.setState({
+                  loading: false,
+                  error: err,
+                });
+                return err;
+              });
+          }
+          return this._promise || Promise.resolve({});
+        },
+      },
+      {
+        key: 'componentDidUpdate',
+        value: function componentDidUpdate(oldProps) {
+          this._setupPromises(oldProps);
+        },
+      },
+      {
+        key: 'componentDidMount',
+        value: function componentDidMount() {
+          this._mounted = true;
+          return this._setupPromises();
         },
       },
       {

--- a/dist/react-hoc-promises.umd.js
+++ b/dist/react-hoc-promises.umd.js
@@ -1532,6 +1532,7 @@ object-assign
       );
 
       _this.state = { loading: true };
+      _this._mounted = false;
       return _this;
     }
 
@@ -1541,25 +1542,30 @@ object-assign
         value: function componentDidMount() {
           var _this2 = this;
 
+          this._mounted = true;
           return Promise.all(Object.values(this.props.promisesMap))
             .then(function(datas) {
-              var state = Object.keys(_this2.props.promisesMap).reduce(function(
-                acc,
-                key,
-                index,
-              ) {
-                return _extends({}, acc, defineProperty({}, key, datas[index]));
-              },
-              {});
-              _this2.setState(
-                _extends(
-                  {
-                    loading: false,
-                    error: null,
+              if (_this2._mounted) {
+                var state = Object.keys(_this2.props.promisesMap).reduce(
+                  function(acc, key, index) {
+                    return _extends(
+                      {},
+                      acc,
+                      defineProperty({}, key, datas[index]),
+                    );
                   },
-                  state,
-                ),
-              );
+                  {},
+                );
+                _this2.setState(
+                  _extends(
+                    {
+                      loading: false,
+                      error: null,
+                    },
+                    state,
+                  ),
+                );
+              }
               return datas;
             })
             .catch(function(err) {
@@ -1569,6 +1575,12 @@ object-assign
               });
               return err;
             });
+        },
+      },
+      {
+        key: 'componentWillUnmount',
+        value: function componentWillUnmount() {
+          this._mounted = false;
         },
       },
       {

--- a/src/PromisesWrapper.js
+++ b/src/PromisesWrapper.js
@@ -10,10 +10,17 @@ class PromisesWrapper extends React.Component {
 
   componentDidMount() {
     this._mounted = true;
-    return Promise.all(Object.values(this.props.promisesMap))
+
+    const { mapPromisesToProps } = this.props;
+    const promisesMap =
+      typeof mapPromisesToProps === 'function'
+        ? mapPromisesToProps(this.props)
+        : mapPromisesToProps;
+
+    return Promise.all(Object.values(promisesMap))
       .then(datas => {
         if (this._mounted) {
-          const state = Object.keys(this.props.promisesMap).reduce(
+          const state = Object.keys(promisesMap).reduce(
             (acc, key, index) => ({ ...acc, [key]: datas[index] }),
             {},
           );
@@ -45,12 +52,15 @@ class PromisesWrapper extends React.Component {
 }
 
 PromisesWrapper.propTypes = {
-  promisesMap: PropTypes.shape({}),
+  mapPromisesToProps: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.func,
+  ]),
   render: PropTypes.func.isRequired,
 };
 
 PromisesWrapper.defaultProps = {
-  promisesMap: {},
+  mapPromisesToProps: {},
 };
 
 export default PromisesWrapper;

--- a/src/PromisesWrapper.js
+++ b/src/PromisesWrapper.js
@@ -5,20 +5,24 @@ class PromisesWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.state = { loading: true };
+    this._mounted = false;
   }
 
   componentDidMount() {
+    this._mounted = true;
     return Promise.all(Object.values(this.props.promisesMap))
       .then(datas => {
-        const state = Object.keys(this.props.promisesMap).reduce(
-          (acc, key, index) => ({ ...acc, [key]: datas[index] }),
-          {},
-        );
-        this.setState({
-          loading: false,
-          error: null,
-          ...state,
-        });
+        if (this._mounted) {
+          const state = Object.keys(this.props.promisesMap).reduce(
+            (acc, key, index) => ({ ...acc, [key]: datas[index] }),
+            {},
+          );
+          this.setState({
+            loading: false,
+            error: null,
+            ...state,
+          });
+        }
         return datas;
       })
       .catch(err => {
@@ -28,6 +32,10 @@ class PromisesWrapper extends React.Component {
         });
         return err;
       });
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
   }
 
   render() {

--- a/src/PromisesWrapper.js
+++ b/src/PromisesWrapper.js
@@ -8,37 +8,63 @@ class PromisesWrapper extends React.Component {
     this._mounted = false;
   }
 
-  componentDidMount() {
-    this._mounted = true;
-
+  _setupPromises(oldProps) {
     const { mapPromisesToProps } = this.props;
+
+    const oldPromisesMap = this._promisesMap;
     const promisesMap =
       typeof mapPromisesToProps === 'function'
-        ? mapPromisesToProps(this.props)
+        ? mapPromisesToProps(this.props, oldProps, oldPromisesMap)
         : mapPromisesToProps;
 
-    return Promise.all(Object.values(promisesMap))
-      .then(datas => {
-        if (this._mounted) {
-          const state = Object.keys(promisesMap).reduce(
-            (acc, key, index) => ({ ...acc, [key]: datas[index] }),
-            {},
-          );
+    this._promisesMap = promisesMap;
+
+    const promises = Object.values(promisesMap);
+    const oldPromises = oldPromisesMap && Object.values(oldPromisesMap);
+    if (
+      !oldPromises ||
+      promises.length !== oldPromises.length ||
+      promises.find((p, i) => p !== oldPromises[i])
+    ) {
+      if (this._mounted) {
+        this.setState({
+          loading: true,
+        });
+      }
+      this._promise = Promise.all(Object.values(promisesMap))
+        .then(datas => {
+          // Ignore results if this request has been superceded
+          if (this._mounted && promisesMap === this._promisesMap) {
+            const state = Object.keys(promisesMap).reduce(
+              (acc, key, index) => ({ ...acc, [key]: datas[index] }),
+              {},
+            );
+            this.setState({
+              loading: false,
+              error: null,
+              ...state,
+            });
+          }
+          return datas;
+        })
+        .catch(err => {
           this.setState({
             loading: false,
-            error: null,
-            ...state,
+            error: err,
           });
-        }
-        return datas;
-      })
-      .catch(err => {
-        this.setState({
-          loading: false,
-          error: err,
+          return err;
         });
-        return err;
-      });
+    }
+    return this._promise || Promise.resolve({});
+  }
+
+  componentDidUpdate(oldProps) {
+    this._setupPromises(oldProps);
+  }
+
+  componentDidMount() {
+    this._mounted = true;
+    return this._setupPromises();
   }
 
   componentWillUnmount() {

--- a/src/PromisesWrapper.test.js
+++ b/src/PromisesWrapper.test.js
@@ -8,40 +8,46 @@ describe('withPromises wrapper', () => {
   let wrapperBuilder;
   let wrapper;
   let render;
-  let promisesMap;
+  let mapPromisesToProps;
 
   beforeEach(() => {
     WrappedComponent = () => <div />;
     render = data => <WrappedComponent {...data} />;
     wrapperBuilder = map =>
-      shallow(<PromisesWrapper promisesMap={map} render={render} />);
+      shallow(
+        <PromisesWrapper
+          mapPromisesToProps={map}
+          render={render}
+          test="test"
+        />,
+      );
   });
 
   it('should render the WrappedComponent', () => {
-    promisesMap = {
+    mapPromisesToProps = {
       myPromise: Promise.resolve('some data'),
     };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     expect(wrapper.find(WrappedComponent)).toBePresent();
   });
 
   it('should set loading prop to WrappedComponent', () => {
-    promisesMap = {
+    mapPromisesToProps = {
       myPromise: Promise.resolve('some data'),
     };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     expect(wrapper.find(WrappedComponent)).toHaveProp('loading', true);
   });
 
   it('should set myPromise prop to WrappedComponent when promise is resolved', async () => {
     const myPromise = Promise.resolve('some data');
-    promisesMap = { myPromise };
+    mapPromisesToProps = { myPromise };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     await wrapper.instance().componentDidMount();
     //  State was updated, but not re-rendered yet.
@@ -51,13 +57,26 @@ describe('withPromises wrapper', () => {
     expect(wrapper.find(WrappedComponent)).toHaveProp('loading', false);
   });
 
+  it('should allow promises to be specified in a callback', async () => {
+    mapPromisesToProps = props => ({ myPromise: Promise.resolve(props.test) });
+
+    wrapper = wrapperBuilder(mapPromisesToProps);
+
+    await wrapper.instance().componentDidMount();
+    //  State was updated, but not re-rendered yet.
+    wrapper.update();
+
+    expect(wrapper.find(WrappedComponent)).toHaveProp('myPromise', 'test');
+    expect(wrapper.find(WrappedComponent)).toHaveProp('loading', false);
+  });
+
   it('should set allPromises into WrappedComponent props when promises are resolved', async () => {
     const myPromise1 = Promise.resolve('some data 1');
     const myPromise2 = Promise.resolve('some data 2');
     const myPromise3 = Promise.resolve('some data 3');
     const myPromise4 = Promise.resolve('some data 4');
     const myPromise5 = Promise.resolve('some data 5');
-    promisesMap = {
+    mapPromisesToProps = {
       myPromise1,
       myPromise2,
       myPromise3,
@@ -65,7 +84,7 @@ describe('withPromises wrapper', () => {
       myPromise5,
     };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     await wrapper.instance().componentDidMount();
     //  State was updated, but not re-rendered yet.
@@ -100,7 +119,7 @@ describe('withPromises wrapper', () => {
     const myPromise3 = Promise.resolve('some data 3');
     const myPromise4 = Promise.reject('error');
     const myPromise5 = Promise.resolve('some data 5');
-    promisesMap = {
+    mapPromisesToProps = {
       myPromise1,
       myPromise2,
       myPromise3,
@@ -108,7 +127,7 @@ describe('withPromises wrapper', () => {
       myPromise5,
     };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     try {
       await wrapper.instance().componentDidMount();
@@ -139,9 +158,9 @@ describe('withPromises wrapper', () => {
 
   it('should set myValue prop to WrappedComponent when it is only a value', async () => {
     const myValue = 'A value';
-    promisesMap = { myValue };
+    mapPromisesToProps = { myValue };
 
-    wrapper = wrapperBuilder(promisesMap);
+    wrapper = wrapperBuilder(mapPromisesToProps);
 
     await wrapper.instance().componentDidMount();
 

--- a/src/withPromises.js
+++ b/src/withPromises.js
@@ -8,7 +8,7 @@ function getDisplayName(WrappedComponent) {
 const withPromises = mapPromisesToProps => WrappedComponent => {
   const WithPromises = props => (
     <PromisesWrapper
-      promisesMap={mapPromisesToProps}
+      mapPromisesToProps={mapPromisesToProps}
       render={datas => <WrappedComponent {...datas} {...props} />}
     />
   );


### PR DESCRIPTION
Calling setState on an unmounted component is an error! This is the kind of boilerplate (and error) that this package should be able to save users from writing (and causing).

Also allow a factory function to be passed in place of the current configuration, which if specified should be supplied with props and return a configuration object in the existing format.